### PR TITLE
Add task state (calling LambdaState for now) and use mock functions when simulating

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -22,21 +22,36 @@ $ pip install awsstepfuncs
 ## Usage
 
 ```py
-from awsstepfuncs import PassState, StateMachine
+from awsstepfuncs import LambdaState, PassState, StateMachine
 
 # Define some states
-pass_step1 = PassState("Pass 1", description="Passes its input to its output without performing work")
-pass_step2 = PassState("Pass 2", description="Here is a second pass step")
+pass_step = PassState(
+    "My Pass", description="Passes its input to its output without performing work"
+)
+divide_numbers_resource_uri = (
+    "arn:aws:lambda:ap-southeast-2:710187714096:function:DivideNumbers"
+)
+task_step = LambdaState(
+    "My Lambda",
+    description="Divide numbers task",
+    resource_uri=divide_numbers_resource_uri,
+)
 
 # Define a state machine that orchestrates the states
-pass_step1 >> pass_step2
-state_machine = StateMachine(start_state=pass_step1)
+pass_step >> task_step
+state_machine = StateMachine(start_state=pass_step)
 
 # Compile the state machine to Amazon States Language
 state_machine.compile("state_machine.json")
 
-# Simulate the state machine by executing it
-state_machine.simulate()
+# Simulate the state machine by executing it, use mock functions for tasks
+state_machine.simulate({divide_numbers_resource_uri: lambda: print(1 / 2)})
+```
+```
+Running My Pass
+Passing
+Running My Lambda
+0.5
 ```
 
 

--- a/src/awsstepfuncs/__init__.py
+++ b/src/awsstepfuncs/__init__.py
@@ -4,3 +4,4 @@
 from awsstepfuncs._repo_version import version as __version__  # noqa:F401
 from awsstepfuncs.pass_state import PassState  # noqa: F401
 from awsstepfuncs.state_machine import StateMachine  # noqa: F401
+from awsstepfuncs.task_state import LambdaState  # noqa: F401

--- a/src/awsstepfuncs/state.py
+++ b/src/awsstepfuncs/state.py
@@ -70,3 +70,4 @@ class StateType(Enum):
     """State types in Amazon States Language."""
 
     PASS = "Pass"
+    LAMBDA = "Task"

--- a/src/awsstepfuncs/task_state.py
+++ b/src/awsstepfuncs/task_state.py
@@ -1,0 +1,30 @@
+from typing import Callable, Optional
+
+from awsstepfuncs.state import State, StateType
+
+
+class LambdaState(State):
+    """Lambda state in Amazon States Language.
+
+    A task state represents a single unit of work performed by a state machine.
+    """
+
+    state_type = StateType.LAMBDA
+
+    def __init__(
+        self, name: str, /, *, description: Optional[str] = None, resource_uri: str
+    ):
+        """Initialize a Lambda state.
+
+        Args:
+            name: The name of the state.
+            description: A description of the state.
+            resource_uri: A URI, especially an ARN that uniquely identifies the
+                specific task to execute.
+        """
+        self.resource_uri = resource_uri
+        super().__init__(name, description=description)
+
+    def run(self, mock_fn: Callable) -> None:  # type: ignore
+        """Execute the task state according to Amazon States Language."""
+        mock_fn()

--- a/tests/test_task_state.py
+++ b/tests/test_task_state.py
@@ -1,0 +1,56 @@
+import contextlib
+import json
+from contextlib import redirect_stdout
+from io import StringIO
+
+from awsstepfuncs import LambdaState, PassState, StateMachine
+
+
+def test_task_state(tmp_path):
+    pass_state = PassState("Pass", description="The starting state")
+    dummy_resource_uri = (
+        "arn:aws:lambda:ap-southeast-2:710187714096:function:DivideNumbers"
+    )
+    task_state = LambdaState("Lambda", resource_uri=dummy_resource_uri)
+
+    # Define the state machine
+    pass_state >> task_state
+    state_machine = StateMachine(start_state=pass_state)
+
+    # Check the output from compiling
+    compiled_path = tmp_path / "state_machine.json"
+    state_machine.compile(compiled_path)
+    with compiled_path.open() as fp:
+        compiled = json.load(fp)
+    assert compiled == {
+        "StartAt": pass_state.name,
+        "States": {
+            pass_state.name: {
+                "Comment": pass_state.description,
+                "Type": "Pass",
+                "Next": task_state.name,
+            },
+            task_state.name: {
+                "Type": "Task",
+                "Resource": dummy_resource_uri,
+                "End": True,
+            },
+        },
+    }
+
+    # Simulate the state machine
+    with contextlib.closing(StringIO()) as fp:
+        with redirect_stdout(fp):
+            state_machine.simulate(
+                {dummy_resource_uri: lambda: print(1 / 2)}  # noqa: T001
+            )
+        stdout = fp.getvalue()
+
+    assert (
+        stdout
+        == """Running Pass
+Passing
+Running Lambda
+0.5
+"""
+    )


### PR DESCRIPTION
- StateMachine.simulate() takes a dictionary of AWS Resource URI to mock functions to run during the simulation

Idea is to isolate mock functions to only the simulation part of the program because mock functions are not part of the Amazon States Language domain model.

- Add new "Resource" key to the compiled output when it's a task state