### PR TITLE
Add validation for duplicate state names

### DIFF
--- a/src/awsstepfuncs/state_machine.py
+++ b/src/awsstepfuncs/state_machine.py
@@ -14,13 +14,26 @@ class StateMachine:
     def __init__(self, *, start_state: State):
         """Initialize a state machine.
 
-        A state machine will contain a reference to the start state, the root node in
-        our state machine DAG.
+        A state machine will contain a reference to the start state. All states
+        in the state machine must have a unique name.
 
         Args:
             start_state: The starting state.
+
+        Raises:
+            ValueError: Raised when there are duplicate state names.
         """
+        if not self._has_unique_names(start_state):
+            raise ValueError(
+                "Duplicate names detected in state machine. Names must be unique"
+            )
+
         self.start_state = start_state
+
+    @staticmethod
+    def _has_unique_names(start_state: State) -> bool:
+        all_state_names = [state.name for state in start_state]
+        return len(all_state_names) == len(set(all_state_names))
 
     def compile(self, output_path: Union[str, Path]) -> None:  # noqa: A003
         """Compile a state machine to Amazon States Language.

--- a/tests/test_pass_state.py
+++ b/tests/test_pass_state.py
@@ -58,19 +58,3 @@ Running Pass 3
 Passing
 """
     )
-
-
-def test_one_state(compile_state_machine):
-    pass_state = PassState("My Pass", comment="The only state")
-    state_machine = StateMachine(start_state=pass_state)
-    compiled = compile_state_machine(state_machine)
-    assert compiled == {
-        "StartAt": pass_state.name,
-        "States": {
-            pass_state.name: {
-                "Comment": pass_state.comment,
-                "Type": "Pass",
-                "End": True,
-            },
-        },
-    }

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,0 +1,31 @@
+import pytest
+
+from awsstepfuncs import PassState, StateMachine
+
+
+def test_one_state(compile_state_machine):
+    pass_state = PassState("My Pass", comment="The only state")
+    state_machine = StateMachine(start_state=pass_state)
+    compiled = compile_state_machine(state_machine)
+    assert compiled == {
+        "StartAt": pass_state.name,
+        "States": {
+            pass_state.name: {
+                "Comment": pass_state.comment,
+                "Type": "Pass",
+                "End": True,
+            },
+        },
+    }
+
+
+def test_duplicate_names():
+    duplicate_name = "My Pass"
+    pass_state1 = PassState(duplicate_name)
+    pass_state2 = PassState(duplicate_name)
+    pass_state1 >> pass_state2
+    with pytest.raises(
+        ValueError,
+        match="Duplicate names detected in state machine. Names must be unique",
+    ):
+        StateMachine(start_state=pass_state1)


### PR DESCRIPTION
A state name must be unique within the scope of the entire state machine.