### PR TITLE
Add function that parses JSONPath

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,0 +1,1 @@
+jsonpath_rw==1.4.0

--- a/tests/test_task_state.py
+++ b/tests/test_task_state.py
@@ -38,7 +38,10 @@ def test_task_state(compile_state_machine):
     with contextlib.closing(StringIO()) as fp:
         with redirect_stdout(fp):
             state_machine.simulate(
-                {dummy_resource_uri: lambda: print(1 / 2)}  # noqa: T001
+                state_input={},
+                resource_to_mock_fn={
+                    dummy_resource_uri: lambda: print(1 / 2)  # noqa: T001
+                },
             )
         stdout = fp.getvalue()
 


### PR DESCRIPTION
- Add `state_input` parameter to `StateMachine.simulate()` for passing data to the starting state. Currently doesn't do anything
- Add `StateMachine._apply_json_path()` for validating, parsing, then applying JSONPath to some data (see: https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-paths.html). Currently not used