### PR TITLE
Fix that JSONPath can legally return None

### DIFF
--- a/src/awsstepfuncs/json_path.py
+++ b/src/awsstepfuncs/json_path.py
@@ -13,8 +13,6 @@ def apply_json_path(json_path: str, data: dict) -> Any:
     Raises:
         ValueError: Raised when the JSONPath is invalid (for the subset that
             Amazon States Language uses).
-        ValueError: Raised when the JSONPath does not find any match. There
-            should always be some match found.
 
     Returns:
         The queried data.
@@ -27,8 +25,6 @@ def apply_json_path(json_path: str, data: dict) -> Any:
     parsed_json_path = parse_jsonpath(json_path)
     if matches := [match.value for match in parsed_json_path.find(data)]:
         return matches[0]
-    else:
-        raise ValueError(f'JSONPath "{json_path}" did not find a match')
 
 
 def validate_json_path(json_path: str) -> None:

--- a/tests/test_json_path.py
+++ b/tests/test_json_path.py
@@ -35,7 +35,4 @@ def test_apply_json_path_must_begin_with_dollar(sample_data):
 
 
 def test_apply_json_path_no_match(sample_data):
-    with pytest.raises(
-        ValueError, match=re.escape('JSONPath "$.notfound" did not find a match')
-    ):
-        apply_json_path("$.notfound", sample_data)
+    assert apply_json_path("$.notfound", sample_data) is None


### PR DESCRIPTION
See "Discard the Result and Keep the Original Input ": https://docs.aws.amazon.com/step-functions/latest/dg/input-output-resultpath.html