### PR TITLE
Add ResultPath

### DIFF
--- a/src/awsstepfuncs/state.py
+++ b/src/awsstepfuncs/state.py
@@ -20,6 +20,9 @@ class State(ABC):
         comment: Optional[str] = None,
         input_path: str = "$",
         output_path: str = "$",
+        result_path: Optional[
+            str
+        ] = "$",  # TODO: Only applies to Pass, Task, Parallel (Mixin?)
     ):
         """Initialize a state.
 
@@ -30,16 +33,23 @@ class State(ABC):
                 $ (pass everything).
             output_path: Used to select a portion of the state output. Default
                 is $ (pass everything).
+            result_path: Specifies where (in the input) to place the "output" of
+                the virtual task specified in Result. The input is further filtered
+                as specified by the OutputPath field (if present) before being used
+                as the state's output. Default is $ (pass only the output state).
 
         Raises:
-            ValueError: Raised when the input path or output path is an invalid
-                JSONPath.
+            ValueError: Raised when an invalid JSONPath is specified.
         """
         self.name = name
         self.comment = comment
         self.next_state: Optional[State] = None
 
-        for json_path in [input_path, output_path]:
+        all_json_paths = [input_path, output_path]
+        if result_path:
+            all_json_paths.append(result_path)
+
+        for json_path in all_json_paths:
             try:
                 validate_json_path(json_path)
             except ValueError:
@@ -47,6 +57,7 @@ class State(ABC):
 
         self.input_path = input_path
         self.output_path = output_path
+        self.result_path = result_path
 
     def __init_subclass__(cls) -> None:
         """Validate subclasses.

--- a/src/awsstepfuncs/state_machine.py
+++ b/src/awsstepfuncs/state_machine.py
@@ -201,9 +201,6 @@ class StateMachine:
                 state, only the input state, or the output state as a key of the
                 input state.
 
-        Raises:
-            ValueError: Raised when result_path is invalid.
-
         Returns:
             The state resulting from applying ResultPath.
         """
@@ -222,4 +219,4 @@ class StateMachine:
             return state_input
 
         else:  # pragma: no cover
-            raise ValueError('Illegal result path: "{result_path}"')
+            assert False, "Should never happen"  # noqa: PT015

--- a/src/awsstepfuncs/state_machine.py
+++ b/src/awsstepfuncs/state_machine.py
@@ -1,14 +1,15 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
-from typing import Any, Callable, Dict, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 from awsstepfuncs.json_path import apply_json_path
 from awsstepfuncs.state import State
 from awsstepfuncs.task_state import TaskState
 
-CompiledState = Dict[str, Union[str, bool, Dict[str, str]]]
+CompiledState = Dict[str, Union[str, bool, Dict[str, str], None]]
 
 
 class StateMachine:
@@ -79,6 +80,9 @@ class StateMachine:
         if state.output_path != "$":
             compiled["OutputPath"] = state.output_path
 
+        if state.result_path != "$":
+            compiled["ResultPath"] = state.result_path
+
         if next_state := state.next_state:
             compiled["Next"] = next_state.name
         else:
@@ -144,6 +148,7 @@ class StateMachine:
         # defined
         state_input = apply_json_path(state.input_path, state_input)
 
+        # Run the state to get the state output
         if isinstance(state, TaskState):
             state_output = state.run(
                 state_input, mock_fn=resource_to_mock_fn[state.resource_uri]
@@ -151,13 +156,15 @@ class StateMachine:
         else:
             state_output = state.run(state_input)
 
+        # Apply the ResultSelector to filter the state output
         # TODO: Add Map, Parallel here
         if isinstance(state, TaskState) and (result_selector := state.result_selector):
             state_output = self._apply_result_selector(state_output, result_selector)
 
-        # TODO: Add ResultPath here
-
-        return apply_json_path(state.output_path, state_output)
+        result_path_output = self._apply_result_path(
+            state_input, state_output, state.result_path
+        )
+        return apply_json_path(state.output_path, result_path_output)
 
     @staticmethod
     def _apply_result_selector(
@@ -180,3 +187,39 @@ class StateMachine:
                 new_state_output[key] = extracted
 
         return new_state_output
+
+    @staticmethod
+    def _apply_result_path(
+        state_input: Any, state_output: Any, result_path: Optional[str]
+    ) -> Any:
+        """Apply ResultPath to combine state input with state output.
+
+        Args:
+            state_input: The input state.
+            state_output: The output state.
+            result_path: A string that indicates whether to keep only the output
+                state, only the input state, or the output state as a key of the
+                input state.
+
+        Raises:
+            ValueError: Raised when result_path is invalid.
+
+        Returns:
+            The state resulting from applying ResultPath.
+        """
+        if result_path == "$":
+            # Just keep state output
+            return state_output
+
+        elif result_path is None:
+            # Just keep state input, discard state_output
+            return state_input
+
+        elif match := re.fullmatch(r"\$\.([A-Za-z]+)", result_path):
+            # Move the state output as a key in state input
+            result_key = match.group(1)
+            state_input[result_key] = state_output
+            return state_input
+
+        else:  # pragma: no cover
+            raise ValueError('Illegal result path: "{result_path}"')

--- a/src/awsstepfuncs/task_state.py
+++ b/src/awsstepfuncs/task_state.py
@@ -18,6 +18,9 @@ class TaskState(State):
         /,
         *,
         comment: Optional[str] = None,
+        input_path: str = "$",
+        output_path: str = "$",
+        result_path: Optional[str] = "$",
         resource_uri: str,
         result_selector: Optional[Dict[str, str]] = None,
     ):
@@ -26,6 +29,14 @@ class TaskState(State):
         Args:
             name: The name of the state.
             comment: A human-readable description of the state.
+            input_path: Used to select a portion of the state input. Default is
+                $ (pass everything).
+            output_path: Used to select a portion of the state output. Default
+                is $ (pass everything).
+            result_path: Specifies where (in the input) to place the "output" of
+                the virtual task specified in Result. The input is further filtered
+                as specified by the OutputPath field (if present) before being used
+                as the state's output. Default is $ (pass only the output state).
             resource_uri: A URI, especially an ARN that uniquely identifies the
                 specific task to execute.
             result_selector: Used to manipulate a state's result before
@@ -33,6 +44,7 @@ class TaskState(State):
 
         Raises:
             ValueError: Raised when the result selector is an invalid.
+            ValueError: Raised when an invalid JSONPath is specified.
         """
         self.resource_uri = resource_uri
 
@@ -43,7 +55,13 @@ class TaskState(State):
                 raise
 
         self.result_selector = result_selector
-        super().__init__(name, comment=comment)
+        super().__init__(
+            name,
+            comment=comment,
+            input_path=input_path,
+            output_path=output_path,
+            result_path=result_path,
+        )
 
     @staticmethod
     def _validate_result_selector(result_selector: Dict[str, str]) -> None:

--- a/tests/test_task_state.py
+++ b/tests/test_task_state.py
@@ -118,6 +118,125 @@ def test_result_selector(compile_state_machine, dummy_resource_uri):
     }
 
 
+def test_result_path_only_state_output(compile_state_machine, dummy_resource_uri):
+    task_state = TaskState("Task", resource_uri=dummy_resource_uri, result_path="$")
+    state_machine = StateMachine(start_state=task_state)
+
+    # Check the output from compiling
+    compiled = compile_state_machine(state_machine)
+    assert compiled == {
+        "StartAt": task_state.name,
+        "States": {
+            task_state.name: {
+                "Resource": dummy_resource_uri,
+                "Type": "Task",
+                "End": True,
+            },
+        },
+    }
+
+    # Simulate the state machine
+    state_input = {
+        "comment": "This is a test of the input and output of a Task state.",
+        "details": "Default example",
+        "who": "AWS Step Functions",
+    }
+
+    output_text = "Hello, AWS Step Functions!"
+
+    def mock_fn(_):
+        return output_text
+
+    state_output = state_machine.simulate(
+        state_input=state_input,
+        resource_to_mock_fn={dummy_resource_uri: mock_fn},
+    )
+
+    # Keeps the only the state output
+    assert state_output == output_text
+
+
+def test_result_path_only_state_input(compile_state_machine, dummy_resource_uri):
+    task_state = TaskState("Task", resource_uri=dummy_resource_uri, result_path=None)
+    state_machine = StateMachine(start_state=task_state)
+
+    # Check the output from compiling
+    compiled = compile_state_machine(state_machine)
+    assert compiled == {
+        "StartAt": task_state.name,
+        "States": {
+            task_state.name: {
+                "Resource": dummy_resource_uri,
+                "ResultPath": None,
+                "Type": "Task",
+                "End": True,
+            },
+        },
+    }
+
+    # Simulate the state machine
+    state_input = {
+        "comment": "This is a test of the input and output of a Task state.",
+        "details": "Default example",
+        "who": "AWS Step Functions",
+    }
+
+    def mock_fn(_):
+        return "Hello, AWS Step Functions!"
+
+    state_output = state_machine.simulate(
+        state_input=state_input,
+        resource_to_mock_fn={dummy_resource_uri: mock_fn},
+    )
+
+    # Keeps the only the state output
+    assert state_output == state_input
+
+
+def test_result_path_keep_both(compile_state_machine, dummy_resource_uri):
+    result_key = "taskresult"
+    task_state = TaskState(
+        "Task", resource_uri=dummy_resource_uri, result_path=f"$.{result_key}"
+    )
+    state_machine = StateMachine(start_state=task_state)
+
+    # Check the output from compiling
+    compiled = compile_state_machine(state_machine)
+    assert compiled == {
+        "StartAt": task_state.name,
+        "States": {
+            task_state.name: {
+                "Resource": dummy_resource_uri,
+                "ResultPath": f"$.{result_key}",
+                "Type": "Task",
+                "End": True,
+            },
+        },
+    }
+
+    # Simulate the state machine
+    state_input = {
+        "comment": "This is a test of the input and output of a Task state.",
+        "details": "Default example",
+        "who": "AWS Step Functions",
+    }
+
+    output_text = "Hello, AWS Step Functions!"
+
+    def mock_fn(_):
+        return output_text
+
+    state_output = state_machine.simulate(
+        state_input=state_input,
+        resource_to_mock_fn={dummy_resource_uri: mock_fn},
+    )
+
+    state_input[result_key] = output_text
+
+    # Keeps the only the state output
+    assert state_output == state_input
+
+
 def test_state_has_invalid_result_selector(dummy_resource_uri):
     invalid_result_selector = {"ClusterId.$": "$.dataset*"}
     with pytest.raises(ValueError, match='Unsupported JSONPath operator: "*"'):


### PR DESCRIPTION
Generally I need to find a nice way to handle the different kinds of states, as some fields apply to only {A,B,C} and other fields apply only to {B,C,D}, so there is not a nice clean inheritance strategy for it. Maybe some kind of mixin strategy. Not sure yet!

For now, as we just have the `Task` and `Pass` states, will keep some fields like `result_path` in `State` for simplicity even if they are not shared by all the possible states (not yet in the package).

There's also some parameter duplication between `State` and `TaskState` that is not so nice, but I'm not sure another way to have the docstring properly set, so I think this duplication is the better option.

Other general thoughts: I'm not so happy with having "$" have all of these special meanings, but I'm not sure whether this package should "Python-ify" it or whether it's easier for the end user to have it the same as the Amazon States Language. I think it's probably better to keep it like their documentation so the user can use that. Other field names I have opted to go for the Amazon States Language version instead of what I would normally call it for the same reason.

Closes #11