### PR TITLE
Fix types such that state data is always JSON

### DIFF
--- a/src/awsstepfuncs/state_machine.py
+++ b/src/awsstepfuncs/state_machine.py
@@ -178,9 +178,9 @@ class StateMachine:
     def _simulate_state(
         self,
         state: State,
-        state_input: Any,
+        state_input: Dict[str, Any],
         resource_to_mock_fn: Dict[str, Callable],
-    ) -> Any:
+    ) -> Dict[str, Any]:
         """Simulate a single state.
 
         Args:
@@ -218,7 +218,7 @@ class StateMachine:
 
     @staticmethod
     def _apply_result_selector(
-        state_output: Any, result_selector: Dict[str, str]
+        state_output: Dict[str, Any], result_selector: Dict[str, str]
     ) -> Dict[str, Any]:
         """Apply the ResultSelector to select a portion of the state output.
 
@@ -240,8 +240,10 @@ class StateMachine:
 
     @staticmethod
     def _apply_result_path(
-        state_input: Any, state_output: Any, result_path: Optional[str]
-    ) -> Any:
+        state_input: Dict[str, Any],
+        state_output: Dict[str, Any],
+        result_path: Optional[str],
+    ) -> Dict[str, Any]:
         """Apply ResultPath to combine state input with state output.
 
         Args:

--- a/src/awsstepfuncs/task_state.py
+++ b/src/awsstepfuncs/task_state.py
@@ -101,7 +101,7 @@ class TaskState(State):
             except ValueError:
                 raise
 
-    def run(self, state_input: Any, mock_fn: Callable) -> Any:  # type: ignore
+    def run(self, state_input: Dict[str, Any], mock_fn: Callable) -> Dict[str, Any]:  # type: ignore
         """Execute the task state according to Amazon States Language.
 
         Args:


### PR DESCRIPTION
> The interpreter passes data between states to perform calculations or to dynamically control the state machine’s flow. **All such data MUST be expressed in JSON.**

It might be good to add further validation such as during simulation as it's possible to use JSONPath selectors that return non-JSON output (such as a string or number).

Refs: https://states-language.net/spec.html#data