### PR TITLE
Add test for valid reference paths

### DIFF
--- a/src/awsstepfuncs/json_path.py
+++ b/src/awsstepfuncs/json_path.py
@@ -24,6 +24,7 @@ def apply_json_path(json_path: str, data: dict) -> Any:
 
     parsed_json_path = parse_jsonpath(json_path)
     if matches := [match.value for match in parsed_json_path.find(data)]:
+        assert len(matches) == 1, "There should only be one match possible"
         return matches[0]
 
 

--- a/tests/test_json_path.py
+++ b/tests/test_json_path.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from awsstepfuncs.json_path import apply_json_path
+from awsstepfuncs.json_path import apply_json_path, validate_json_path
 
 
 @pytest.fixture(scope="session")
@@ -36,3 +36,28 @@ def test_apply_json_path_must_begin_with_dollar(sample_data):
 
 def test_apply_json_path_no_match(sample_data):
     assert apply_json_path("$.notfound", sample_data) is None
+
+
+@pytest.mark.parametrize(
+    "reference_path",
+    [
+        r"$.store.book",
+        r"$.store\.book",
+        r"$.\stor\e.boo\k",
+        r"$.store.book.title",
+        r"$.foo.\.bar",
+        # TODO: The following reference path should be valid by example: https://states-language.net/spec.html#ref-paths
+        # But there is a "?" which is considered an invalid operator, but perhaps in
+        # this scenario it's not considered an operator
+        # "$.foo\@bar.baz\[\[.\?pretty",
+        r"$.&Ж中.\uD800\uDF46",
+        r"$.ledgers.branch[0].pending.count",
+        r"$.ledgers.branch[0]",
+        r"$.ledgers[0][22][315].foo",
+        r"$['store']['book']",
+        r"$['store'][0]['book']",
+    ],
+)
+def test_valid_reference_path(reference_path):
+    # Should raise no ValueError
+    validate_json_path(reference_path)

--- a/tests/test_json_path.py
+++ b/tests/test_json_path.py
@@ -59,5 +59,5 @@ def test_apply_json_path_no_match(sample_data):
     ],
 )
 def test_valid_reference_path(reference_path):
-    # Should raise no ValueError
+    # Should not raise any ValueError
     validate_json_path(reference_path)


### PR DESCRIPTION
Found examples here: https://states-language.net/spec.html#ref-paths

Additionally added a defensive assert that there should only be one match when applying a reference path.