### PR TITLE
Rename State to AbstractState

### DIFF
--- a/src/awsstepfuncs/pass_state.py
+++ b/src/awsstepfuncs/pass_state.py
@@ -1,9 +1,9 @@
 from typing import Any, Optional
 
-from awsstepfuncs.state import State, StateType
+from awsstepfuncs.state import AbstractState, StateType
 
 
-class PassState(State):
+class PassState(AbstractState):
     """Pass state in Amazon States Language.
 
     A Pass state passes its input to its outputs without performing work.

--- a/src/awsstepfuncs/state.py
+++ b/src/awsstepfuncs/state.py
@@ -9,7 +9,7 @@ from awsstepfuncs.json_path import validate_json_path
 MAX_STATE_NAME_LENGTH = 128
 
 
-class State(ABC):
+class AbstractState(ABC):
     """An AWS Step Functions state."""
 
     state_type: Optional[StateType] = None
@@ -52,7 +52,7 @@ class State(ABC):
 
         self.name = name
         self.comment = comment
-        self.next_state: Optional[State] = None
+        self.next_state: Optional[AbstractState] = None
 
         all_json_paths = [input_path, output_path]
         if result_path:
@@ -81,7 +81,7 @@ class State(ABC):
         if not cls.state_type:  # pragma: no cover
             raise ValueError("Must specify state_type attribute")
 
-    def __rshift__(self, other: State, /) -> State:
+    def __rshift__(self, other: AbstractState, /) -> AbstractState:
         """Overload >> operator when state execution order.
 
         Args:
@@ -93,12 +93,12 @@ class State(ABC):
         self.next_state = other
         return other
 
-    def __iter__(self) -> State:
+    def __iter__(self) -> AbstractState:
         """Iterate through the states."""
-        self._current: Optional[State] = self
+        self._current: Optional[AbstractState] = self
         return self._current
 
-    def __next__(self) -> State:
+    def __next__(self) -> AbstractState:
         """Get the next state."""
         current = self._current
         if not current:

--- a/src/awsstepfuncs/state_machine.py
+++ b/src/awsstepfuncs/state_machine.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, Optional, Union
 
 from awsstepfuncs.json_path import apply_json_path
 from awsstepfuncs.pass_state import PassState
-from awsstepfuncs.state import State
+from awsstepfuncs.state import AbstractState
 from awsstepfuncs.task_state import TaskState
 
 CompiledState = Dict[str, Union[str, bool, Dict[str, str], None]]
@@ -19,7 +19,7 @@ class StateMachine:
     def __init__(
         self,
         *,
-        start_state: State,
+        start_state: AbstractState,
         comment: Optional[str] = None,
         version: Optional[str] = None,
     ):
@@ -47,7 +47,7 @@ class StateMachine:
         self.version = version
 
     @staticmethod
-    def _has_unique_names(start_state: State) -> bool:
+    def _has_unique_names(start_state: AbstractState) -> bool:
         all_state_names = [state.name for state in start_state]
         return len(all_state_names) == len(set(all_state_names))
 
@@ -74,7 +74,7 @@ class StateMachine:
         with output_path.open("w") as fp:
             json.dump(compiled, fp)
 
-    def _compile_state(self, state: State, /) -> CompiledState:
+    def _compile_state(self, state: AbstractState, /) -> CompiledState:
         """Compile a state to Amazon States Language.
 
         Args:
@@ -122,7 +122,9 @@ class StateMachine:
             compiled["Result"] = result
 
     @staticmethod
-    def _compile_generic_state_fields(compiled: CompiledState, state: State) -> None:
+    def _compile_generic_state_fields(
+        compiled: CompiledState, state: AbstractState
+    ) -> None:
         """Compile state fields that are common to all states.
 
         Args:
@@ -177,7 +179,7 @@ class StateMachine:
 
     def _simulate_state(
         self,
-        state: State,
+        state: AbstractState,
         state_input: Any,
         resource_to_mock_fn: Dict[str, Callable],
     ) -> Any:

--- a/src/awsstepfuncs/task_state.py
+++ b/src/awsstepfuncs/task_state.py
@@ -1,10 +1,10 @@
 from typing import Any, Callable, Dict, Optional
 
 from awsstepfuncs.json_path import validate_json_path
-from awsstepfuncs.state import State, StateType
+from awsstepfuncs.state import AbstractState, StateType
 
 
-class TaskState(State):
+class TaskState(AbstractState):
     """Task state in Amazon States Language.
 
     A task state represents a single unit of work performed by a state machine.


### PR DESCRIPTION
All ABC's should have Abstract as a prefix for clarity.