### PR TITLE
Fix unique name validation with catchers

### DIFF
--- a/src/awsstepfuncs/state.py
+++ b/src/awsstepfuncs/state.py
@@ -654,8 +654,8 @@ class AbstractRetryCatchState(AbstractResultSelectorState):
             kwargs: Kwargs to pass to parent classes.
         """
         super().__init__(*args, **kwargs)
-        self._retriers: List[Retrier] = []
-        self._catchers: List[Catcher] = []
+        self.retriers: List[Retrier] = []
+        self.catchers: List[Catcher] = []
 
     def compile(self) -> Dict[str, Any]:  # noqa: A003
         """Compile the state to Amazon States Language.
@@ -665,9 +665,9 @@ class AbstractRetryCatchState(AbstractResultSelectorState):
             Language.
         """
         compiled = super().compile()
-        if retriers := self._retriers:
+        if retriers := self.retriers:
             compiled["Retry"] = [retrier.compile() for retrier in retriers]
-        if catchers := self._catchers:
+        if catchers := self.catchers:
             compiled["Catch"] = [catcher.compile() for catcher in catchers]
         return compiled
 
@@ -703,7 +703,7 @@ class AbstractRetryCatchState(AbstractResultSelectorState):
             backoff_rate=backoff_rate,
             max_attempts=max_attempts,
         )
-        self._retriers.append(retrier)
+        self.retriers.append(retrier)
         return self
 
     def add_catcher(
@@ -729,7 +729,7 @@ class AbstractRetryCatchState(AbstractResultSelectorState):
             error_equals=error_equals,
             next_state=next_state,
         )
-        self._catchers.append(catcher)
+        self.catchers.append(catcher)
         return self
 
 

--- a/src/awsstepfuncs/state_machine.py
+++ b/src/awsstepfuncs/state_machine.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
-from awsstepfuncs.state import AbstractState
+from awsstepfuncs.state import AbstractRetryCatchState, AbstractState
 from awsstepfuncs.types import ResourceToMockFn
 
 CompiledState = Dict[str, Union[str, bool, Dict[str, str], None]]
@@ -55,7 +55,14 @@ class StateMachine:
         Returns:
             Whether all states have unique names.
         """
-        all_state_names = [state.name for state in start_state]
+        all_states = set()
+        for state in start_state:
+            all_states.add(state)
+            if isinstance(state, AbstractRetryCatchState):
+                for catcher in state.catchers:
+                    all_states.add(catcher.next_state)
+
+        all_state_names = [state.name for state in all_states]
         return len(all_state_names) == len(set(all_state_names))
 
     def compile(self) -> Dict[str, Any]:  # noqa: A003

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,6 +1,7 @@
 import pytest
 
 from awsstepfuncs import PassState, StateMachine
+from awsstepfuncs.state import FailState, TaskState
 
 
 def test_one_state(compile_state_machine):
@@ -33,3 +34,15 @@ def test_duplicate_names():
         match="Duplicate names detected in state machine. Names must be unique",
     ):
         StateMachine(start_state=pass_state1)
+
+
+def test_duplicate_names_catcher():
+    duplicate_name = "Duplicated"
+    task_state = TaskState(duplicate_name, resource="123")
+    transition_state = FailState(duplicate_name, error="MyError", cause="Negligence")
+    task_state.add_catcher(["Something"], next_state=transition_state)
+    with pytest.raises(
+        ValueError,
+        match="Duplicate names detected in state machine. Names must be unique",
+    ):
+        StateMachine(start_state=task_state)


### PR DESCRIPTION
Previously, the state referenced by the "Next" field of a catcher would not be included in the validation of unique state names.