### PR TITLE
Handle catcher's next state recursively

### DIFF
--- a/src/awsstepfuncs/state_machine.py
+++ b/src/awsstepfuncs/state_machine.py
@@ -54,6 +54,14 @@ class StateMachine:
         return self._all_states_recursive(self.start_state)
 
     def _all_states_recursive(self, start_state: AbstractState) -> Set[AbstractState]:
+        """Return all states from the given starting state.
+
+        Args:
+            start_state: The starting state.
+
+        Returns:
+            All possible states from the given starting state.
+        """
         all_states = set()
         for state in start_state:
             all_states.add(state)

--- a/src/awsstepfuncs/state_machine.py
+++ b/src/awsstepfuncs/state_machine.py
@@ -51,12 +51,15 @@ class StateMachine:
         Returns:
             A set of all possible states in the state machine.
         """
+        return self._all_states_recursive(self.start_state)
+
+    def _all_states_recursive(self, start_state: AbstractState) -> Set[AbstractState]:
         all_states = set()
-        for state in self.start_state:
+        for state in start_state:
             all_states.add(state)
             if isinstance(state, AbstractRetryCatchState):
                 for catcher in state.catchers:
-                    all_states.add(catcher.next_state)
+                    all_states |= self._all_states_recursive(catcher.next_state)
         return all_states
 
     def _has_unique_names(self) -> bool:


### PR DESCRIPTION
Previously just the first state from a catcher was handled, but now it is handled recursively (so a catcher's next state of a catcher's next state should definitely be found when finding all states).