### PR TITLE
Hide step from Visualizaion interface

### DIFF
--- a/src/awsstepfuncs/state_machine.py
+++ b/src/awsstepfuncs/state_machine.py
@@ -156,9 +156,7 @@ class StateMachine:
             )
 
             if visualization and next_state:
-                visualization.step()
                 visualization.highlight_state_transition(current_state, next_state)
-                visualization.step()
 
             current_state, current_data = next_state, next_data
             print("State output:", current_data)

--- a/src/awsstepfuncs/visualization.py
+++ b/src/awsstepfuncs/visualization.py
@@ -73,8 +73,6 @@ class Visualization:
             previous_state: The previous state.
             next_state: The next state.
         """
+        self.animation.next_step()
         self.animation.highlight_edge(previous_state.name, next_state.name)
-
-    def step(self) -> None:
-        """Complete a time step of the visualization."""
         self.animation.next_step()


### PR DESCRIPTION
Since we just need `Visualization.step()` in one place, might as well encapsulate it within `Visualization`.